### PR TITLE
Fix: Replace carousel with static tips list

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -149,77 +149,34 @@ header h1 {
     margin-bottom: 15px;
 }
 
-/* Tips carousel */
-#tips-carousel {
-    min-height: 100px; /* Increased from 80px to ensure enough room */
-    position: relative;
+/* Guitar Tips List Styling */
+.guitar-tips-container {
+    max-height: 280px;
+    overflow-y: auto;
+    padding: 0;
+    margin: 0;
 }
 
-#tips-carousel .carousel-inner {
-    min-height: 80px; /* Add fixed height for carousel inner */
-}
-
-#tips-carousel .carousel-item {
-    height: 80px; /* Increased from 60px */
-    padding: 10px;
-    text-align: center;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-#tips-carousel .carousel-item p {
+.guitar-tip {
+    padding: 12px;
+    border-bottom: 1px solid #e9ecef;
     font-size: 0.95rem;
     line-height: 1.5;
-    margin: 0;
-    max-width: 100%;
-    white-space: normal;
-    overflow: hidden;
+    display: flex;
+    align-items: center;
 }
 
-#tips-carousel .carousel-indicators {
-    position: relative;
-    margin-top: 10px;
-    margin-bottom: 0;
+.guitar-tip:last-child {
+    border-bottom: none;
 }
 
-#tips-carousel .carousel-indicators button {
-    width: 10px;
-    height: 10px;
-    border-radius: 50%;
-    background-color: #6c757d;
-    opacity: 0.5;
-    margin: 0 4px;
+.guitar-tip:hover {
+    background-color: #f8f9fa;
 }
 
-#tips-carousel .carousel-indicators button.active {
-    opacity: 1;
-}
-
-#tips-carousel .carousel-control-prev,
-#tips-carousel .carousel-control-next {
-    width: 10%;
-    background: rgba(0, 0, 0, 0.1);
-    border-radius: 20px;
-    height: 30px;
-    top: 25px;
-    opacity: 0.7;
-    color: #6c757d;
-}
-
-#tips-carousel .carousel-control-prev {
-    left: 5px;
-}
-
-#tips-carousel .carousel-control-next {
-    right: 5px;
-}
-
-#tips-carousel .carousel-control-prev-icon,
-#tips-carousel .carousel-control-next-icon {
-    width: 15px;
-    height: 15px;
-    filter: invert(60%) sepia(10%) saturate(300%) hue-rotate(175deg) brightness(88%) contrast(90%);
+.guitar-tip i {
+    font-size: 1.1rem;
+    min-width: 24px;
 }
 
 /* Mobile responsiveness */

--- a/index.html
+++ b/index.html
@@ -54,38 +54,21 @@
                         <h5 class="mb-0">Guitar Pro Tips</h5>
                     </div>
                     <div class="card-body">
-                        <div id="tips-carousel" class="carousel slide" data-bs-ride="carousel" data-bs-interval="5000">
-                            <div class="carousel-inner">
-                                <div class="carousel-item active">
-                                    <p class="m-0"><i class="fas fa-lightbulb text-warning me-2"></i> Use the <strong>Slow Down</strong> tool to learn difficult sections at a manageable pace.</p>
-                                </div>
-                                <div class="carousel-item">
-                                    <p class="m-0"><i class="fas fa-lightbulb text-warning me-2"></i> <strong>Loop Sections</strong> to master challenging parts before moving on.</p>
-                                </div>
-                                <div class="carousel-item">
-                                    <p class="m-0"><i class="fas fa-lightbulb text-warning me-2"></i> Use the <strong>Mixer</strong> to isolate the guitar track you're learning.</p>
-                                </div>
-                                <div class="carousel-item">
-                                    <p class="m-0"><i class="fas fa-lightbulb text-warning me-2"></i> Switch between <strong>Tab and Notation</strong> views to improve your music reading.</p>
-                                </div>
-                                <div class="carousel-item">
-                                    <p class="m-0"><i class="fas fa-lightbulb text-warning me-2"></i> Practice with a <strong>metronome</strong> to improve your timing.</p>
-                                </div>
+                        <div id="guitar-tips-list" class="guitar-tips-container">
+                            <div class="guitar-tip">
+                                <i class="fas fa-lightbulb text-warning me-2"></i> Use the <strong>Slow Down</strong> tool to learn difficult sections at a manageable pace.
                             </div>
-                            <button class="carousel-control-prev" type="button" data-bs-target="#tips-carousel" data-bs-slide="prev">
-                                <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-                                <span class="visually-hidden">Previous</span>
-                            </button>
-                            <button class="carousel-control-next" type="button" data-bs-target="#tips-carousel" data-bs-slide="next">
-                                <span class="carousel-control-next-icon" aria-hidden="true"></span>
-                                <span class="visually-hidden">Next</span>
-                            </button>
-                            <div class="carousel-indicators position-relative mt-2">
-                                <button type="button" data-bs-target="#tips-carousel" data-bs-slide-to="0" class="active" aria-current="true" aria-label="Tip 1"></button>
-                                <button type="button" data-bs-target="#tips-carousel" data-bs-slide-to="1" aria-label="Tip 2"></button>
-                                <button type="button" data-bs-target="#tips-carousel" data-bs-slide-to="2" aria-label="Tip 3"></button>
-                                <button type="button" data-bs-target="#tips-carousel" data-bs-slide-to="3" aria-label="Tip 4"></button>
-                                <button type="button" data-bs-target="#tips-carousel" data-bs-slide-to="4" aria-label="Tip 5"></button>
+                            <div class="guitar-tip">
+                                <i class="fas fa-lightbulb text-warning me-2"></i> <strong>Loop Sections</strong> to master challenging parts before moving on.
+                            </div>
+                            <div class="guitar-tip">
+                                <i class="fas fa-lightbulb text-warning me-2"></i> Use the <strong>Mixer</strong> to isolate the guitar track you're learning.
+                            </div>
+                            <div class="guitar-tip">
+                                <i class="fas fa-lightbulb text-warning me-2"></i> Switch between <strong>Tab and Notation</strong> views to improve your music reading.
+                            </div>
+                            <div class="guitar-tip">
+                                <i class="fas fa-lightbulb text-warning me-2"></i> Practice with a <strong>metronome</strong> to improve your timing.
                             </div>
                         </div>
                     </div>

--- a/js/main.js
+++ b/js/main.js
@@ -6,11 +6,6 @@ document.addEventListener('DOMContentLoaded', function() {
     
     // Setup event listeners
     setupEventListeners();
-    
-    // Initialize tips carousel
-    let tipsCarousel = new bootstrap.Carousel(document.getElementById('tips-carousel'), {
-        interval: 5000
-    });
 });
 
 // Initialize the application


### PR DESCRIPTION
## Description

This PR fixes issue #1 by replacing the problematic carousel with a static list of guitar tips.

### Changes made:

1. Removed the carousel component from the HTML and replaced it with a static list of tips
2. Added new CSS styling for the tips list with a clean, easy-to-read layout
3. Removed the carousel initialization from the JavaScript to clean up the code

### Benefits:

- Cleaner layout with better readability
- No more overlapping controls or text
- Simpler user experience - all tips are immediately visible
- Improved maintainability by removing complex carousel component

The static list is more reliable and provides a better user experience than the previously buggy carousel.
